### PR TITLE
Fix inline link whitespace tricks

### DIFF
--- a/static/regexes.js
+++ b/static/regexes.js
@@ -74,7 +74,7 @@ const regex_types = [
         copy_btn: document.getElementById("copy-regex-inline-links"),
         output: document.getElementById("regex-output-inline-links"),
         generator: function(settings) {
-            return `\\[.*\\]\\(<?(?:https?://)?[a-z0-9_\\-\\.]*[a-z0-9_\\-]+\\.[a-z]{2,}.*>?\\)`
+            return `\\[.*\\n*.*\\]\\(\\s*<?(?:https?://)?[a-z0-9_\\-\\.]*[a-z0-9_\\-]+\\.[a-z]{2,}.*>?\\s*\\)`
         },
         setting_elements: {}
     },


### PR DESCRIPTION
The current inline link regex misses the following cases which Discord considers valid:

- Link text containing newlines, e.g.
```
[exam
ple](http://example.com)
```
- Links URLs with leading or trailing whitespace, e.g. `[example]( http://example.com)`

This PR patches these tricks.

Cheers!