### PR TITLE
Update regexes.js invite-links to fix double ++

### DIFF
--- a/static/regexes.js
+++ b/static/regexes.js
@@ -98,7 +98,7 @@ const regex_types = [
         copy_btn: document.getElementById("copy-regex-invite-links"),
         output: document.getElementById("regex-output-invite-links"),
         generator: function(settings) {
-            const main_invites = `(?:https?:\\/\\/)?(?:www\\.|ptb\\.|canary\\.)?discord(?:app)?\\.(?:(?:com|gg)[/\\\\]+(?:invite|servers)[/\\\\]++[a-z0-9-_]+)`;
+            const main_invites = `(?:https?:\\/\\/)?(?:www\\.|ptb\\.|canary\\.)?discord(?:app)?\\.(?:(?:com|gg)[/\\\\]+(?:invite|servers)[/\\\\]+[a-z0-9-_]+)`;
             if (settings.third_party.checked) {
                 return `${main_invites}|(?:https?://)?(?:www\\.)?(?:dsc\\.gg|invite\\.gg+|discord\\.link|(?:discord\\.(gg|io|me|li|id))|disboard\\.org)[/\\\\]+[a-z0-9-_/]+`;
             } else {


### PR DESCRIPTION
The generated code had `++` which broke RegEx parsing, only a single `+` should be there